### PR TITLE
New Version perkeep 0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Multi-stage docker build for perkeep
-ARG GOLANG_VERSION=1.10
+ARG GOLANG_VERSION=1.15
 FROM golang:${GOLANG_VERSION}-alpine as builder
-ARG PERKEEP_REF=0.10
+ARG PERKEEP_REF=0.11
 
 # Dependencies
 RUN apk add --no-cache git ca-certificates sqlite-dev
 RUN mkdir -p /go/src
 
 # Build perkeep
-RUN git clone https://camlistore.googlesource.com/camlistore /go/src/perkeep.org
+RUN git clone https://github.com/perkeep/perkeep.git /go/src/perkeep.org
 WORKDIR /go/src/perkeep.org
 RUN git checkout "$PERKEEP_REF"
 RUN go run make.go


### PR DESCRIPTION
```
> docker build -t perkeep . 
Sending build context to Docker daemon  418.3kB
Step 1/26 : ARG GOLANG_VERSION=1.15
Step 2/26 : FROM golang:${GOLANG_VERSION}-alpine as builder
 ---> 1de1afaeaa9a
Step 3/26 : ARG PERKEEP_REF=0.11
 ---> Using cache
 ---> 46d35b565b70
Step 4/26 : RUN apk add --no-cache git ca-certificates sqlite-dev
 ---> Using cache
 ---> d790199eb7c5
Step 5/26 : RUN mkdir -p /go/src
 ---> Using cache
 ---> 0ae87f95cd7d
Step 6/26 : RUN git clone https://github.com/perkeep/perkeep.git /go/src/perkeep.org
 ---> Running in 3f0192f6af67
Cloning into '/go/src/perkeep.org'...
Removing intermediate container 3f0192f6af67
 ---> e6295309dd3d
Step 7/26 : WORKDIR /go/src/perkeep.org
 ---> Running in 4fb6cda93de6
Removing intermediate container 4fb6cda93de6
 ---> a5ad2c180ab8
Step 8/26 : RUN git checkout "$PERKEEP_REF"
 ---> Running in 482977ecb0b8
Note: switching to '0.11'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 76755286 VERSION: set to 0.11
Removing intermediate container 482977ecb0b8
 ---> 880e5ebdf335
Step 9/26 : RUN go run make.go
 ---> Running in f47f00736a68
go: downloading go4.org v0.0.0-20190218023631-ce4c26f7be8e
go: downloading github.com/rwcarlsen/goexif v0.0.0-20180518182100-8d986c03457a
go: downloading github.com/lib/pq v1.1.1
go: downloading golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0
go: downloading cloud.google.com/go v0.39.0
go: downloading github.com/syndtr/goleveldb v0.0.0-20180608030153-db3ee9ee8931
go: downloading gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
go: downloading golang.org/x/net v0.0.0-20190522155817-f3200d17e092
go: downloading github.com/hjfreyer/taglib-go v0.0.0-20151027170453-0ef8bba9c41b
go: downloading github.com/go-sql-driver/mysql v1.4.1-0.20180719071942-99ff426eb706
go: downloading google.golang.org/api v0.5.0
go: downloading github.com/nf/cr2 v0.0.0-20140528043846-05d46fef4f2f
go: downloading github.com/googleapis/gax-go/v2 v2.0.4
go: downloading golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
go: downloading github.com/bradfitz/latlong v0.0.0-20140711231157-b74550508561
go: downloading rsc.io/qr v0.1.0
go: downloading google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69
go: downloading github.com/golang/protobuf v1.3.1
go: downloading google.golang.org/grpc v1.21.0
go: downloading golang.org/x/sys v0.0.0-20190528183647-3626398d7749
go: downloading go.opencensus.io v0.21.0
go: downloading golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: downloading golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff
go: downloading golang.org/x/text v0.3.2
go: downloading github.com/golang/snappy v0.0.0-20170215233205-553a64147049
go: downloading github.com/gorilla/websocket v1.4.0
go: downloading github.com/hashicorp/golang-lru v0.5.1
go: downloading github.com/cznic/kv v0.0.0-20170515202733-892ccf731fb7
go: downloading github.com/cznic/lldb v1.1.0
go: downloading github.com/cznic/internal v0.0.0-20170905175358-4747030f7cf2
go: downloading github.com/cznic/fileutil v0.0.0-20180108211300-6a051e75936f
go: downloading github.com/cznic/mathutil v0.0.0-20180214153908-5455a562bccb
go: downloading github.com/cznic/zappy v0.0.0-20160723133515-2533cb5b45cc
go: downloading github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65
go: downloading github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712
go4.org/rollsum
perkeep.org/pkg/fileembed/genfileembed
go: downloading bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898
go: downloading github.com/aws/aws-sdk-go v1.14.31
go: downloading golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
go: downloading rsc.io/pdf v0.0.0-20170302045715-1d34785eb915
go: downloading github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66
go: downloading github.com/tgulacsi/picago v0.0.0-20171229130838-9e1ac2306c70
go: downloading github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317
go: downloading github.com/plaid/plaid-go v0.0.0-20161222051224-02b6af68061b
go: downloading github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
go: downloading github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17
go: downloading github.com/go-ini/ini v1.38.1
go: downloading github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
perkeep.org/pkg/constants
go4.org/legal
golang.org/x/image/math/f64
perkeep.org/pkg/schema/nodeattr
golang.org/x/net/html/atom
golang.org/x/text/encoding/internal/identifier
golang.org/x/text/internal/utf8internal
perkeep.org/pkg/importer/feed/rss
google.golang.org/grpc/resolver
go.opencensus.io
go.opencensus.io/trace/internal
vendor/golang.org/x/crypto/poly1305
golang.org/x/crypto/openpgp/errors
golang.org/x/text/transform
golang.org/x/crypto/cast5
perkeep.org/internal/lru
vendor/golang.org/x/crypto/curve25519
perkeep.org/internal/netutil
go4.org/errorutil
go4.org/wkfs
perkeep.org/pkg/buildinfo
perkeep.org/internal/testhooks
go4.org/syncutil
vendor/golang.org/x/crypto/chacha20poly1305
go4.org/types
golang.org/x/text/unicode/bidi
golang.org/x/text/unicode/norm
go4.org/jsonconfig
golang.org/x/net/http2/hpack
perkeep.org/pkg/blob
golang.org/x/crypto/openpgp/armor
golang.org/x/crypto/openpgp/elgamal
crypto/tls
golang.org/x/crypto/openpgp/s2k
perkeep.org/internal/gpgagent
perkeep.org/internal/pinentry
perkeep.org/internal/osutil
perkeep.org/internal/hashutil
perkeep.org/pkg/blobserver/protocol
golang.org/x/crypto/openpgp/packet
golang.org/x/text/secure/bidirule
perkeep.org/pkg/camerrors
github.com/bradfitz/latlong
github.com/rwcarlsen/goexif/tiff
go4.org/strutil
go4.org/syncutil/singleflight
golang.org/x/net/context
github.com/hjfreyer/taglib-go/taglib/id3
go4.org/media/heif/bmff
github.com/rwcarlsen/goexif/exif
github.com/nf/cr2
golang.org/x/image/tiff/lzw
golang.org/x/net/idna
github.com/hjfreyer/taglib-go/taglib
golang.org/x/image/draw
golang.org/x/image/tiff
go4.org/media/heif
github.com/syndtr/goleveldb/leveldb/comparer
github.com/syndtr/goleveldb/leveldb/storage
github.com/syndtr/goleveldb/leveldb/util
perkeep.org/pkg/types/serverconfig
golang.org/x/crypto/openpgp
perkeep.org/pkg/cmdmain
golang.org/x/net/xsrftoken
golang.org/x/net/http/httpguts
perkeep.org/pkg/blobserver/local
rsc.io/qr/gf256
golang.org/x/net/html
golang.org/x/text/encoding
rsc.io/qr/coding
golang.org/x/text/runes
github.com/syndtr/goleveldb/leveldb/errors
perkeep.org/pkg/jsonsign
github.com/syndtr/goleveldb/leveldb/iterator
golang.org/x/text/encoding/internal
golang.org/x/text/internal/tag
rsc.io/qr
perkeep.org/internal/images/resize
golang.org/x/text/encoding/charmap
github.com/syndtr/goleveldb/leveldb/memdb
golang.org/x/text/encoding/japanese
perkeep.org/pkg/sorted
golang.org/x/text/encoding/korean
golang.org/x/text/encoding/simplifiedchinese
golang.org/x/text/encoding/traditionalchinese
golang.org/x/text/encoding/unicode
net/http/httptrace
golang.org/x/text/internal/language
net/http
perkeep.org/pkg/importer/feed/atom
perkeep.org/pkg/importer/feed/rdf
golang.org/x/oauth2/jws
golang.org/x/sync/errgroup
golang.org/x/time/rate
google.golang.org/api/googleapi/internal/uritemplates
golang.org/x/net/internal/timeseries
google.golang.org/grpc/grpclog
github.com/golang/protobuf/proto
google.golang.org/grpc/credentials/internal
google.golang.org/grpc/internal
google.golang.org/grpc/metadata
google.golang.org/grpc/connectivity
google.golang.org/grpc/internal/grpcrand
golang.org/x/text/internal/language/compact
google.golang.org/grpc/codes
google.golang.org/grpc/encoding
golang.org/x/sys/unix
google.golang.org/grpc/internal/balancerload
google.golang.org/grpc/internal/envconfig
google.golang.org/grpc/internal/backoff
google.golang.org/grpc/internal/grpcsync
google.golang.org/grpc/keepalive
golang.org/x/text/language
google.golang.org/grpc/stats
google.golang.org/grpc/tap
google.golang.org/grpc/naming
google.golang.org/grpc/resolver/dns
google.golang.org/grpc/resolver/passthrough
github.com/hashicorp/golang-lru/simplelru
go.opencensus.io/internal
go.opencensus.io/trace/tracestate
go.opencensus.io/resource
go.opencensus.io/internal/tagencoding
go.opencensus.io/tag
github.com/tomnomnom/linkheader
go.opencensus.io/metric/metricdata
golang.org/x/text/encoding/htmlindex
go.opencensus.io/trace
github.com/syndtr/goleveldb/leveldb/cache
go.opencensus.io/metric/metricproducer
github.com/syndtr/goleveldb/leveldb/filter
golang.org/x/net/html/charset
go.opencensus.io/stats/internal
github.com/syndtr/goleveldb/leveldb/journal
github.com/golang/snappy
github.com/syndtr/goleveldb/leveldb/opt
go.opencensus.io/stats
perkeep.org/internal/chanworker
github.com/cznic/fileutil
github.com/cznic/mathutil
go.opencensus.io/stats/view
google.golang.org/grpc/internal/syscall
go4.org/lock
github.com/edsrzf/mmap-go
github.com/cznic/sortutil
github.com/syndtr/goleveldb/leveldb/table
perkeep.org/internal/leak
perkeep.org/pkg/blobserver/stats
cloud.google.com/go/internal/optional
perkeep.org/pkg/sorted/sqlkv
cloud.google.com/go/internal/version
google.golang.org/api/iterator
github.com/lib/pq/oid
github.com/go-sql-driver/mysql
github.com/lib/pq/scram
gopkg.in/mgo.v2/internal/json
gopkg.in/mgo.v2/internal/scram
github.com/syndtr/goleveldb/leveldb
github.com/lib/pq
github.com/cznic/internal/slice
cloud.google.com/go/logging/internal
google.golang.org/grpc/credentials
google.golang.org/grpc/encoding/proto
github.com/golang/protobuf/ptypes/any
github.com/golang/protobuf/ptypes/duration
github.com/golang/protobuf/ptypes/timestamp
google.golang.org/grpc/balancer
google.golang.org/genproto/googleapis/rpc/status
github.com/golang/protobuf/ptypes
google.golang.org/grpc/balancer/base
google.golang.org/grpc/binarylog/grpc_binarylog_v1
google.golang.org/grpc/status
google.golang.org/grpc/internal/channelz
google.golang.org/grpc/balancer/roundrobin
google.golang.org/grpc/peer
github.com/cznic/internal/buffer
google.golang.org/grpc/internal/binarylog
github.com/golang/protobuf/protoc-gen-go/descriptor
google.golang.org/genproto/googleapis/type/expr
google.golang.org/genproto/googleapis/rpc/code
github.com/cznic/internal/file
github.com/cznic/zappy
gopkg.in/mgo.v2/bson
github.com/golang/protobuf/ptypes/struct
google.golang.org/genproto/googleapis/api/label
github.com/cznic/lldb
go4.org/readerutil
golang.org/x/net/http2
cloud.google.com/go/compute/metadata
perkeep.org/pkg/blobserver
perkeep.org/internal/magic
github.com/gorilla/websocket
perkeep.org/pkg/env
perkeep.org/pkg/types/camtypes
golang.org/x/net/context/ctxhttp
perkeep.org/pkg/blobserver/memory
golang.org/x/oauth2/internal
perkeep.org/pkg/schema
golang.org/x/oauth2
perkeep.org/internal/images/fastjpeg
perkeep.org/internal/media
go4.org/ctxutil
perkeep.org/internal/images
github.com/garyburd/go-oauth/oauth
perkeep.org/internal/geocode
perkeep.org/pkg/fileembed
perkeep.org/internal/closure
perkeep.org/pkg/blobserver/files
golang.org/x/oauth2/jwt
perkeep.org/server/perkeepd/ui/closure
perkeep.org/clients/web/embed/fontawesome
perkeep.org/clients/web/embed/keepy
perkeep.org/clients/web/embed/leaflet
perkeep.org/clients/web/embed/less
perkeep.org/clients/web/embed/opensans
perkeep.org/clients/web/embed/react
perkeep.org/pkg/client/android
golang.org/x/oauth2/google
perkeep.org/server/perkeepd/ui
perkeep.org/pkg/index
google.golang.org/api/googleapi
golang.org/x/net/trace
perkeep.org/pkg/blobserver/localdisk
perkeep.org/pkg/cacher
go.opencensus.io/trace/propagation
google.golang.org/api/googleapi/transport
google.golang.org/api/gensupport
perkeep.org/internal/httputil
google.golang.org/grpc/internal/transport
go.opencensus.io/plugin/ochttp/propagation/b3
google.golang.org/api/transport/http/internal/propagation
github.com/tgulacsi/picago
go.opencensus.io/plugin/ochttp
github.com/mattn/go-mastodon
perkeep.org/pkg/auth
perkeep.org/pkg/blobserver/gethandler
perkeep.org/pkg/types/clientconfig
github.com/plaid/plaid-go/plaid
perkeep.org/pkg/jsonsign/signhandler
github.com/cznic/kv
perkeep.org/pkg/sorted/leveldb
perkeep.org/pkg/sorted/sqlite
perkeep.org/pkg/blobserver/handlers
perkeep.org/pkg/kvutil
google.golang.org/genproto/googleapis/api/annotations
cloud.google.com/go/internal/trace
go4.org/oauthutil
perkeep.org/pkg/search
perkeep.org/pkg/sorted/kvfile
gopkg.in/mgo.v2
go.opencensus.io/plugin/ocgrpc
google.golang.org/grpc/credentials/oauth
google.golang.org/genproto/googleapis/api
github.com/golang/protobuf/ptypes/empty
perkeep.org/pkg/blobserver/diskpacked
google.golang.org/genproto/googleapis/api/distribution
google.golang.org/grpc
google.golang.org/genproto/googleapis/logging/type
google.golang.org/genproto/protobuf/field_mask
google.golang.org/genproto/googleapis/api/monitoredres
google.golang.org/genproto/googleapis/api/metric
golang.org/x/sync/semaphore
perkeep.org/pkg/sorted/postgres
golang.org/x/crypto/acme
perkeep.org/pkg/blobserver/dir
google.golang.org/api/support/bundler
perkeep.org/internal/azure/storage
github.com/FiloSottile/b2
perkeep.org/internal/pools
perkeep.org/pkg/conv
perkeep.org/pkg/blobserver/cond
golang.org/x/crypto/acme/autocert
perkeep.org/pkg/blobserver/blobpacked
golang.org/x/crypto/internal/subtle
perkeep.org/pkg/blobserver/b2
perkeep.org/pkg/blobserver/azure
golang.org/x/crypto/poly1305
perkeep.org/pkg/sorted/mongo
golang.org/x/crypto/salsa20/salsa
golang.org/x/crypto/pbkdf2
perkeep.org/pkg/blobserver/mongo
golang.org/x/crypto/scrypt
perkeep.org/pkg/blobserver/overlay
perkeep.org/pkg/blobserver/proxycache
perkeep.org/pkg/client
perkeep.org/pkg/server/app
perkeep.org/pkg/blobserver/replica
github.com/aws/aws-sdk-go/aws/awserr
github.com/aws/aws-sdk-go/internal/shareddefaults
github.com/go-ini/ini
google.golang.org/api/internal
github.com/googleapis/gax-go/v2
google.golang.org/genproto/googleapis/iam/v1
google.golang.org/genproto/googleapis/logging/v2
golang.org/x/crypto/nacl/secretbox
google.golang.org/api/option
cloud.google.com/go/internal
perkeep.org/pkg/blobserver/encrypt
github.com/aws/aws-sdk-go/aws/endpoints
github.com/aws/aws-sdk-go/internal/sdkio
github.com/aws/aws-sdk-go/aws/client/metadata
google.golang.org/api/transport/http
cloud.google.com/go/iam
google.golang.org/api/drive/v3
google.golang.org/api/storage/v1
google.golang.org/api/transport/grpc
google.golang.org/api/compute/v1
google.golang.org/api/drive/v2
perkeep.org/pkg/server
perkeep.org/cmd/pk-get
perkeep.org/cmd/pk-put
google.golang.org/api/transport
cloud.google.com/go/logging/apiv2
perkeep.org/pkg/importer
cloud.google.com/go/logging
cloud.google.com/go/storage
perkeep.org/pkg/serverinit
google.golang.org/api/sqladmin/v1beta4
perkeep.org/pkg/blobserver/google/drive/service
perkeep.org/pkg/importer/dummy
perkeep.org/pkg/importer/feed
perkeep.org/pkg/importer/flickr
perkeep.org/pkg/importer/picasa
perkeep.org/pkg/importer/instapaper
perkeep.org/pkg/importer/mastodon
perkeep.org/pkg/importer/gphotos
perkeep.org/pkg/importer/pinboard
perkeep.org/pkg/importer/plaid
perkeep.org/pkg/importer/swarm
perkeep.org/pkg/importer/twitter
go4.org/wkfs/gcs
perkeep.org/pkg/blobserver/google/drive
perkeep.org/pkg/sorted/mysql
google.golang.org/api/cloudresourcemanager/v1
google.golang.org/api/servicemanagement/v1
go4.org/cloud/google/gcsutil
perkeep.org/pkg/blobserver/remote
github.com/aws/aws-sdk-go/aws/credentials
github.com/jmespath/go-jmespath
perkeep.org/pkg/blobserver/google/cloudstorage
perkeep.org/pkg/importer/allimporters
github.com/aws/aws-sdk-go/aws
perkeep.org/dev/devcam
github.com/aws/aws-sdk-go/internal/sdkrand
github.com/aws/aws-sdk-go/internal/sdkuri
github.com/aws/aws-sdk-go/private/protocol/eventstream
go4.org/fault
perkeep.org/pkg/blobserver/shard
perkeep.org/pkg/blobserver/union
perkeep.org/pkg/camlegal
perkeep.org/pkg/gpgchallenge
go4.org/net/throttle
perkeep.org/pkg/webserver/listen
perkeep.org/pkg/app
github.com/aws/aws-sdk-go/aws/awsutil
perkeep.org/pkg/webserver
perkeep.org/pkg/publish
perkeep.org/app/scanningcabinet/ui
rsc.io/pdf
perkeep.org/app/hello
bazil.org/fuse
perkeep.org/app/publisher
github.com/aws/aws-sdk-go/aws/request
perkeep.org/app/scanningcabinet
github.com/aws/aws-sdk-go/aws/client
github.com/aws/aws-sdk-go/aws/corehandlers
github.com/aws/aws-sdk-go/private/protocol
github.com/aws/aws-sdk-go/aws/csm
github.com/aws/aws-sdk-go/aws/ec2metadata
github.com/aws/aws-sdk-go/private/protocol/rest
github.com/aws/aws-sdk-go/private/protocol/query/queryutil
github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi
github.com/aws/aws-sdk-go/aws/signer/v4
github.com/aws/aws-sdk-go/aws/defaults
github.com/aws/aws-sdk-go/private/protocol/query
perkeep.org/app/scanningcabinet/scancab
github.com/aws/aws-sdk-go/private/protocol/restxml
github.com/aws/aws-sdk-go/service/sts
github.com/aws/aws-sdk-go/service/s3
github.com/aws/aws-sdk-go/aws/credentials/stscreds
github.com/aws/aws-sdk-go/aws/session
bazil.org/fuse/fuseutil
bazil.org/fuse/fs
perkeep.org/pkg/fs
perkeep.org/cmd/pk-mount
go4.org/cloud/google/gceutil
perkeep.org/internal/osutil/gce
perkeep.org/pkg/deploy/gce
perkeep.org/cmd/pk
github.com/aws/aws-sdk-go/service/s3/s3iface
github.com/aws/aws-sdk-go/service/s3/s3manager
perkeep.org/cmd/pk-deploy
perkeep.org/pkg/blobserver/s3
perkeep.org/server/perkeepd
Success. Binaries are in /go/bin
Removing intermediate container f47f00736a68
 ---> 34328f6b0a7d
Step 10/26 : WORKDIR /go/src/github.com/jhillyerd/perkeep-docker
 ---> Running in 747b200fef01
Removing intermediate container 747b200fef01
 ---> ffd7b8019eb4
Step 11/26 : COPY . .
 ---> df0e875f43b6
Step 12/26 : RUN go install ./...
 ---> Running in dbde2ba12700
Removing intermediate container dbde2ba12700
 ---> ff2422ee0134
Step 13/26 : FROM alpine:3.5
 ---> f80194ae2e0c
Step 14/26 : RUN apk add --no-cache ca-certificates libjpeg-turbo-utils
 ---> Running in 8b09cb8b8d28
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz
(1/3) Installing ca-certificates (20161130-r1)
(2/3) Installing libjpeg-turbo (1.5.3-r2)
(3/3) Installing libjpeg-turbo-utils (1.5.3-r2)
Executing busybox-1.25.1-r2.trigger
Executing ca-certificates-20161130-r1.trigger
OK: 6 MiB in 14 packages
Removing intermediate container 8b09cb8b8d28
 ---> b94afe5b5949
Step 15/26 : WORKDIR /usr/bin
 ---> Running in 9aec344c22fd
Removing intermediate container 9aec344c22fd
 ---> 2c6c69fba72a
Step 16/26 : COPY --from=builder /go/bin/perkeepd .
 ---> 07b561089e16
Step 17/26 : COPY --from=builder /go/bin/genkey .
 ---> 11448e9e69f7
Step 18/26 : COPY run-perkeep.sh /
 ---> dee8e65bddeb
Step 19/26 : RUN adduser -g Perkeep -D perkeep
 ---> Running in 9fc4793e62fe
Removing intermediate container 9fc4793e62fe
 ---> 883c5e29178f
Step 20/26 : RUN mkdir /config && chown perkeep: /config
 ---> Running in ac88049a0e99
Removing intermediate container ac88049a0e99
 ---> bbcfca502ac8
Step 21/26 : RUN mkdir /storage && chown perkeep: /storage
 ---> Running in cdcc6f9a4e83
Removing intermediate container cdcc6f9a4e83
 ---> 1d0c5133253e
Step 22/26 : VOLUME /config
 ---> Running in 501ede2a6281
Removing intermediate container 501ede2a6281
 ---> db66d0cba77d
Step 23/26 : VOLUME /storage
 ---> Running in 75d5aa63342a
Removing intermediate container 75d5aa63342a
 ---> a56d791059af
Step 24/26 : EXPOSE 3179
 ---> Running in abb2a02b7219
Removing intermediate container abb2a02b7219
 ---> bc3f047f8705
Step 25/26 : USER perkeep
 ---> Running in 234fa9d5ea4c
Removing intermediate container 234fa9d5ea4c
 ---> 62872b3140c9
Step 26/26 : CMD ["/run-perkeep.sh"]
 ---> Running in c3a1d32b7f25
Removing intermediate container c3a1d32b7f25
 ---> 7b517f6f289f
Successfully built 7b517f6f289f
Successfully tagged perkeep:latest
```